### PR TITLE
Refactor configuration-driven client factory resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,5 @@
 
 - Client providers use `IClientProvider` for configuration-driven creation of chat, speech-to-text, and text-to-speech clients.
 - `IClientProvider` and `IClientFactory` are the canonical provider/factory APIs; do not add chat-only compatibility abstractions.
+- Resolve section-bound `IClientFactory` instances through `ClientFactoryResolver`; do not register or depend on an unbound singleton `IClientFactory`.
 - Provider-created clients should expose the bound provider options through `GetService(typeof(object), "options")` and typed options requests.

--- a/readme.md
+++ b/readme.md
@@ -45,15 +45,17 @@ var grok = app.Services.GetRequiredKeyedService<IChatClient>("Grok");
 Changing the `appsettings.json` file will automatically update the client 
 configuration without restarting the application.
 
-The same provider resolution can also create speech clients from configuration 
-through `IClientFactory`:
+The same provider resolution can also create speech clients from configuration
+through keyed `IClientFactory` registrations:
 
 ```csharp
+host.AddClients();
+
 var section = host.Configuration.GetRequiredSection("AI:Clients:OpenAI");
-var factory = app.Services.GetRequiredService<IClientFactory>();
-var chat = factory.CreateChatClient(section);
-var speechToText = factory.CreateSpeechToTextClient(section);
-var textToSpeech = factory.CreateTextToSpeechClient(section);
+var factory = app.Services.GetRequiredKeyedService<IClientFactory>(section.Path);
+var chat = factory.CreateChatClient();
+var speechToText = factory.CreateSpeechToTextClient();
+var textToSpeech = factory.CreateTextToSpeechClient();
 ```
 
 There's also a simpler `Chat` class for streamlined creation of chat messages, which can 

--- a/src/Extensions/ClientFactoryExtensions.cs
+++ b/src/Extensions/ClientFactoryExtensions.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Devlooped.Extensions.AI;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -11,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class ClientFactoryExtensions
 {
-    /// <summary>Adds the default <see cref="IClientFactory"/> and built-in providers to the service collection.</summary>
+    /// <summary>Adds the default <see cref="ClientFactoryResolver"/> and built-in providers to the service collection.</summary>
     /// <param name="services">The service collection.</param>
     /// <param name="registerDefaults">Whether to register the default built-in providers.</param>
     /// <returns>The service collection for chaining.</returns>
@@ -25,19 +24,64 @@ public static class ClientFactoryExtensions
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IClientProvider, GrokClientProvider>());
         }
 
-        services.TryAddSingleton<ClientFactory>();
-        services.TryAddSingleton<IClientFactory>(sp => sp.GetRequiredService<ClientFactory>());
+        services.TryAddSingleton<ClientFactoryResolver>();
+        services.TryAddSingleton<IClientFactoryResolver>(sp => sp.GetRequiredService<ClientFactoryResolver>());
 
         return services;
     }
 
-    /// <summary>Adds the default <see cref="IClientFactory"/> and built-in providers to the host application builder.</summary>
+    /// <summary>Adds the default <see cref="ClientFactoryResolver"/> and built-in providers to the host application builder.</summary>
     /// <param name="builder">The host application builder.</param>
     /// <param name="registerDefaults">Whether to register the default built-in providers.</param>
     /// <returns>The builder for chaining.</returns>
     public static TBuilder AddClientFactory<TBuilder>(this TBuilder builder, bool registerDefaults = true) where TBuilder : IHostApplicationBuilder
     {
         builder.Services.AddClientFactory(registerDefaults);
+        return builder;
+    }
+
+    /// <summary>Adds keyed <see cref="IClientFactory"/> registrations for configuration sections with direct API keys.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="prefix">The configuration prefix for clients. Defaults to <c>ai:clients</c>.</param>
+    /// <param name="useDefaultProviders">Whether to register the default built-in providers.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddClients(this IServiceCollection services, IConfiguration configuration, string prefix = "ai:clients", bool useDefaultProviders = true)
+    {
+        services.AddClientFactory(useDefaultProviders);
+
+        foreach (var section in EnumerateFactorySections(configuration, prefix))
+        {
+            services.TryAdd(new ServiceDescriptor(typeof(IClientFactory), section.Path,
+                factory: (sp, _) => sp.GetRequiredService<IClientFactoryResolver>().Resolve(section),
+                ServiceLifetime.Singleton));
+
+            services.TryAdd(new ServiceDescriptor(typeof(IClientFactory), new ServiceKey(section.Path),
+                factory: (sp, _) => sp.GetRequiredKeyedService<IClientFactory>(section.Path),
+                ServiceLifetime.Singleton));
+
+            var dottedKey = section.Path.Replace(':', '.');
+
+            services.TryAdd(new ServiceDescriptor(typeof(IClientFactory), dottedKey,
+                factory: (sp, _) => sp.GetRequiredService<IClientFactoryResolver>().Resolve(section),
+                ServiceLifetime.Singleton));
+
+            services.TryAdd(new ServiceDescriptor(typeof(IClientFactory), new ServiceKey(dottedKey),
+                factory: (sp, _) => sp.GetRequiredKeyedService<IClientFactory>(section.Path),
+                ServiceLifetime.Singleton));
+        }
+
+        return services;
+    }
+
+    /// <summary>Adds keyed <see cref="IClientFactory"/> registrations for configuration sections with direct API keys.</summary>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="prefix">The configuration prefix for clients. Defaults to <c>ai:clients</c>.</param>
+    /// <param name="useDefaultProviders">Whether to register the default built-in providers.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static TBuilder AddClients<TBuilder>(this TBuilder builder, string prefix = "ai:clients", bool useDefaultProviders = true) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddClients(builder.Configuration, prefix, useDefaultProviders);
         return builder;
     }
 
@@ -48,7 +92,7 @@ public static class ClientFactoryExtensions
     public static IServiceCollection AddClientProvider<TProvider>(this IServiceCollection services)
         where TProvider : class, IClientProvider
     {
-        services.AddEnumerable(ServiceDescriptor.Singleton<IClientProvider, TProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IClientProvider, TProvider>());
         return services;
     }
 
@@ -62,93 +106,23 @@ public static class ClientFactoryExtensions
         Func<IServiceProvider, TProvider> implementationFactory)
         where TProvider : class, IClientProvider
     {
-        services.AddEnumerable(ServiceDescriptor.Singleton<IClientProvider>(implementationFactory));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IClientProvider>(implementationFactory));
         return services;
     }
 
-    /// <summary>Registers an inline <see cref="IClientProvider"/> with the specified name, base URI, host suffix, and factory functions.</summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="name">The unique name for the provider.</param>
-    /// <param name="baseUri">The optional base URI for automatic endpoint matching.</param>
-    /// <param name="hostSuffix">The optional host suffix for automatic endpoint matching (e.g., ".openai.azure.com").</param>
-    /// <param name="chatFactory">The factory function to create chat clients.</param>
-    /// <param name="speechToTextFactory">The optional factory function to create speech-to-text clients.</param>
-    /// <param name="textToSpeechFactory">The optional factory function to create text-to-speech clients.</param>
-    /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddClientProvider(
-        this IServiceCollection services,
-        string name,
-        Uri? baseUri,
-        string? hostSuffix,
-        Func<IConfigurationSection, IChatClient> chatFactory,
-        Func<IConfigurationSection, ISpeechToTextClient>? speechToTextFactory = null,
-        Func<IConfigurationSection, ITextToSpeechClient>? textToSpeechFactory = null)
+    static IEnumerable<IConfigurationSection> EnumerateFactorySections(IConfiguration configuration, string prefix)
     {
-        services.AddEnumerable(ServiceDescriptor.Singleton<IClientProvider>(
-            new DelegateClientProvider(name, baseUri, hostSuffix, chatFactory, speechToTextFactory, textToSpeechFactory)));
-        return services;
-    }
+        var normalizedPrefix = prefix.TrimEnd(':') + ":";
+        HashSet<string> sections = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Registers an inline <see cref="IClientProvider"/> with the specified name, base URI, and factory functions.</summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="name">The unique name for the provider.</param>
-    /// <param name="baseUri">The optional base URI for automatic endpoint matching.</param>
-    /// <param name="chatFactory">The factory function to create chat clients.</param>
-    /// <param name="speechToTextFactory">The optional factory function to create speech-to-text clients.</param>
-    /// <param name="textToSpeechFactory">The optional factory function to create text-to-speech clients.</param>
-    /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddClientProvider(
-        this IServiceCollection services,
-        string name,
-        Uri? baseUri,
-        Func<IConfigurationSection, IChatClient> chatFactory,
-        Func<IConfigurationSection, ISpeechToTextClient>? speechToTextFactory = null,
-        Func<IConfigurationSection, ITextToSpeechClient>? textToSpeechFactory = null)
-        => services.AddClientProvider(name, baseUri, null, chatFactory, speechToTextFactory, textToSpeechFactory);
-
-    /// <summary>Registers an inline <see cref="IClientProvider"/> with the specified name and factory functions.</summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="name">The unique name for the provider.</param>
-    /// <param name="chatFactory">The factory function to create chat clients.</param>
-    /// <param name="speechToTextFactory">The optional factory function to create speech-to-text clients.</param>
-    /// <param name="textToSpeechFactory">The optional factory function to create text-to-speech clients.</param>
-    /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddClientProvider(
-        this IServiceCollection services,
-        string name,
-        Func<IConfigurationSection, IChatClient> chatFactory,
-        Func<IConfigurationSection, ISpeechToTextClient>? speechToTextFactory = null,
-        Func<IConfigurationSection, ITextToSpeechClient>? textToSpeechFactory = null)
-        => services.AddClientProvider(name, null, null, chatFactory, speechToTextFactory, textToSpeechFactory);
-
-    static void AddEnumerable(this IServiceCollection services, ServiceDescriptor descriptor)
-        // Use TryAddEnumerable behavior to avoid duplicates
-        => services.TryAddEnumerable(descriptor);
-
-    /// <summary>A delegate-based <see cref="IClientProvider"/> for inline registrations.</summary>
-    sealed class DelegateClientProvider(
-        string name,
-        Uri? baseUri,
-        string? hostSuffix,
-        Func<IConfigurationSection, IChatClient> chatFactory,
-        Func<IConfigurationSection, ISpeechToTextClient>? speechToTextFactory,
-        Func<IConfigurationSection, ITextToSpeechClient>? textToSpeechFactory) : IClientProvider
-    {
-        public string ProviderName => name;
-        public Uri? BaseUri => baseUri;
-        public string? HostSuffix => hostSuffix;
-        public IClientFactory GetFactory() => new DelegateClientFactory(chatFactory, speechToTextFactory, textToSpeechFactory);
-    }
-
-    sealed class DelegateClientFactory(
-        Func<IConfigurationSection, IChatClient> chatFactory,
-        Func<IConfigurationSection, ISpeechToTextClient>? speechToTextFactory,
-        Func<IConfigurationSection, ITextToSpeechClient>? textToSpeechFactory) : IClientFactory
-    {
-        public IChatClient CreateChatClient(IConfigurationSection section) => chatFactory(section);
-        public ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section)
-            => speechToTextFactory?.Invoke(section) ?? throw new NotSupportedException("Speech-to-text clients are not supported by this provider.");
-        public ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section)
-            => textToSpeechFactory?.Invoke(section) ?? throw new NotSupportedException("Text-to-speech clients are not supported by this provider.");
+        foreach (var entry in configuration.AsEnumerable().Where(x =>
+            x.Value is not null &&
+            x.Key.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase) &&
+            x.Key.EndsWith(":apikey", StringComparison.OrdinalIgnoreCase)))
+        {
+            var sectionPath = string.Join(':', entry.Key.Split(':')[..^1]);
+            if (sections.Add(sectionPath))
+                yield return configuration.GetRequiredSection(sectionPath);
+        }
     }
 }

--- a/src/Extensions/ClientFactoryResolver.cs
+++ b/src/Extensions/ClientFactoryResolver.cs
@@ -1,10 +1,9 @@
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 
 namespace Devlooped.Extensions.AI;
 
-/// <summary>Default implementation of <see cref="IClientFactory"/> that resolves providers by name or by matching endpoint URIs.</summary>
-public class ClientFactory : IClientFactory
+/// <summary>Resolves providers by name or by matching endpoint URIs, then returns section-bound factories.</summary>
+public class ClientFactoryResolver : IClientFactoryResolver
 {
     readonly IClientProvider defaultProvider = new OpenAIClientProvider();
 
@@ -12,9 +11,9 @@ public class ClientFactory : IClientFactory
     readonly List<(Uri BaseUri, IClientProvider Provider)> providersByBaseUri;
     readonly List<(string HostSuffix, IClientProvider Provider)> providersByHostSuffix;
 
-    /// <summary>Initializes a new instance of the <see cref="ClientFactory"/> class with the specified providers.</summary>
+    /// <summary>Initializes a new instance of the <see cref="ClientFactoryResolver"/> class with the specified providers.</summary>
     /// <param name="providers">The collection of registered providers.</param>
-    public ClientFactory(IEnumerable<IClientProvider> providers)
+    public ClientFactoryResolver(IEnumerable<IClientProvider> providers)
     {
         providersByName = new(StringComparer.OrdinalIgnoreCase);
         providersByBaseUri = [];
@@ -37,9 +36,9 @@ public class ClientFactory : IClientFactory
         providersByHostSuffix.Sort((a, b) => b.HostSuffix.Length.CompareTo(a.HostSuffix.Length));
     }
 
-    /// <summary>Creates a <see cref="ClientFactory"/> with the built-in providers registered.</summary>
-    /// <returns>A factory with OpenAI, Azure OpenAI, Azure AI Inference, and Grok providers.</returns>
-    public static ClientFactory CreateDefault() => new(
+    /// <summary>Creates a <see cref="ClientFactoryResolver"/> with the built-in providers registered.</summary>
+    /// <returns>A resolver with OpenAI, Azure OpenAI, Azure AI Inference, and Grok providers.</returns>
+    public static ClientFactoryResolver CreateDefault() => new(
     [
         new OpenAIClientProvider(),
         new AzureOpenAIClientProvider(),
@@ -48,16 +47,7 @@ public class ClientFactory : IClientFactory
     ]);
 
     /// <inheritdoc/>
-    public IChatClient CreateChatClient(IConfigurationSection section)
-        => ResolveProvider(section).GetFactory().CreateChatClient(section);
-
-    /// <inheritdoc/>
-    public ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section)
-        => ResolveProvider(section).GetFactory().CreateSpeechToTextClient(section);
-
-    /// <inheritdoc/>
-    public ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section)
-        => ResolveProvider(section).GetFactory().CreateTextToSpeechClient(section);
+    public IClientFactory Resolve(IConfigurationSection section) => ResolveProvider(section).GetFactory(section);
 
     /// <summary>Resolves the appropriate provider for the given configuration section.</summary>
     /// <param name="section">The configuration section.</param>

--- a/src/Extensions/ClientProviders.cs
+++ b/src/Extensions/ClientProviders.cs
@@ -15,19 +15,17 @@ namespace Devlooped.Extensions.AI;
 /// </summary>
 sealed class OpenAIClientProvider : IClientProvider
 {
-    static readonly IClientFactory factory = new OpenAIClientFactory();
-
     public string ProviderName => "openai";
 
     public Uri? BaseUri => new("https://api.openai.com/");
 
     public string? HostSuffix => null;
 
-    public IClientFactory GetFactory() => factory;
+    public IClientFactory GetFactory(IConfigurationSection section) => new OpenAIClientFactory(section);
 
-    class OpenAIClientFactory : IClientFactory
+    class OpenAIClientFactory(IConfigurationSection section) : IClientFactory
     {
-        public IChatClient CreateChatClient(IConfigurationSection section)
+        public IChatClient CreateChatClient()
         {
             var options = section.Get<OpenAIProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -38,7 +36,7 @@ sealed class OpenAIClientProvider : IClientProvider
                 options);
         }
 
-        public ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section)
+        public ISpeechToTextClient CreateSpeechToTextClient()
         {
             var options = section.Get<OpenAIProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -49,7 +47,7 @@ sealed class OpenAIClientProvider : IClientProvider
                 options);
         }
 
-        public ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section)
+        public ITextToSpeechClient CreateTextToSpeechClient()
         {
             var options = section.Get<OpenAIProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -73,19 +71,17 @@ sealed class OpenAIClientProvider : IClientProvider
 /// </summary>
 sealed class AzureOpenAIClientProvider : IClientProvider
 {
-    static readonly IClientFactory factory = new AzureOpenAIClientFactory();
-
     public string ProviderName => "azure.openai";
 
     public Uri? BaseUri => null;
 
     public string? HostSuffix => ".openai.azure.com";
 
-    public IClientFactory GetFactory() => factory;
+    public IClientFactory GetFactory(IConfigurationSection section) => new AzureOpenAIClientFactory(section);
 
-    class AzureOpenAIClientFactory : IClientFactory
+    class AzureOpenAIClientFactory(IConfigurationSection section) : IClientFactory
     {
-        public IChatClient CreateChatClient(IConfigurationSection section)
+        public IChatClient CreateChatClient()
         {
             var options = section.Get<AzureOpenAIProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -97,7 +93,7 @@ sealed class AzureOpenAIClientProvider : IClientProvider
                 options);
         }
 
-        public ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section)
+        public ISpeechToTextClient CreateSpeechToTextClient()
         {
             var options = section.Get<AzureOpenAIProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -111,7 +107,7 @@ sealed class AzureOpenAIClientProvider : IClientProvider
                 options);
         }
 
-        public ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section)
+        public ITextToSpeechClient CreateTextToSpeechClient()
         {
             var options = section.Get<AzureOpenAIProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -140,7 +136,6 @@ sealed class AzureOpenAIClientProvider : IClientProvider
 sealed class AzureAIInferenceClientProvider : IClientProvider
 {
     const string providerName = "azure.inference";
-    static readonly IClientFactory factory = new AzureAIInferenceClientFactory();
 
     public string ProviderName => providerName;
 
@@ -148,11 +143,11 @@ sealed class AzureAIInferenceClientProvider : IClientProvider
 
     public string? HostSuffix => null;
 
-    public IClientFactory GetFactory() => factory;
+    public IClientFactory GetFactory(IConfigurationSection section) => new AzureAIInferenceClientFactory(section);
 
-    class AzureAIInferenceClientFactory : IClientFactory
+    class AzureAIInferenceClientFactory(IConfigurationSection section) : IClientFactory
     {
-        public IChatClient CreateChatClient(IConfigurationSection section)
+        public IChatClient CreateChatClient()
         {
             var options = section.Get<AzureInferenceProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -165,10 +160,10 @@ sealed class AzureAIInferenceClientProvider : IClientProvider
                 options);
         }
 
-        public ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section)
+        public ISpeechToTextClient CreateSpeechToTextClient()
             => throw ClientProviderCapabilities.Unsupported(providerName, nameof(ISpeechToTextClient));
 
-        public ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section)
+        public ITextToSpeechClient CreateTextToSpeechClient()
             => throw ClientProviderCapabilities.Unsupported(providerName, nameof(ITextToSpeechClient));
     }
 
@@ -186,7 +181,6 @@ sealed class AzureAIInferenceClientProvider : IClientProvider
 sealed class GrokClientProvider : IClientProvider
 {
     const string providerName = "xai";
-    static readonly IClientFactory factory = new GrokClientFactory();
 
     public string ProviderName => providerName;
 
@@ -194,11 +188,11 @@ sealed class GrokClientProvider : IClientProvider
 
     public string? HostSuffix => null;
 
-    public IClientFactory GetFactory() => factory;
+    public IClientFactory GetFactory(IConfigurationSection section) => new GrokClientFactory(section);
 
-    class GrokClientFactory : IClientFactory
+    class GrokClientFactory(IConfigurationSection section) : IClientFactory
     {
-        public IChatClient CreateChatClient(IConfigurationSection section)
+        public IChatClient CreateChatClient()
         {
             var options = section.Get<GrokProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
@@ -209,22 +203,20 @@ sealed class GrokClientProvider : IClientProvider
                 options);
         }
 
-        public ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section)
+        public ISpeechToTextClient CreateSpeechToTextClient()
         {
             var options = section.Get<GrokProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
-            Throw.IfNullOrEmpty(options.ModelId, $"{section.Path}:modelid");
 
             return new ProviderOptionsSpeechToTextClient<GrokClientOptions>(
                 new GrokClient(options.ApiKey, options).AsISpeechToTextClient(),
                 options);
         }
 
-        public ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section)
+        public ITextToSpeechClient CreateTextToSpeechClient()
         {
             var options = section.Get<GrokProviderOptions>() ?? new();
             Throw.IfNullOrEmpty(options.ApiKey, $"{section.Path}:apikey");
-            Throw.IfNullOrEmpty(options.ModelId, $"{section.Path}:modelid");
 
             return new ProviderOptionsTextToSpeechClient<GrokClientOptions>(
                 new GrokClient(options.ApiKey, options).AsITextToSpeechClient(),

--- a/src/Extensions/ConfigurableChatClient.cs
+++ b/src/Extensions/ConfigurableChatClient.cs
@@ -9,7 +9,7 @@ namespace Devlooped.Extensions.AI;
 public sealed partial class ConfigurableChatClient : IChatClient, IDisposable
 {
     readonly IConfiguration configuration;
-    readonly IClientFactory factory;
+    readonly IClientFactoryResolver resolver;
     readonly string section;
     readonly string id;
     readonly ILogger logger;
@@ -20,18 +20,18 @@ public sealed partial class ConfigurableChatClient : IChatClient, IDisposable
 
     /// <summary>Initializes a new instance of the <see cref="ConfigurableChatClient"/> class.</summary>
     /// <param name="configuration">The configuration to read settings from.</param>
-    /// <param name="factory">The factory to use for creating chat clients.</param>
+    /// <param name="resolver">The resolver to use for creating provider-specific factories.</param>
     /// <param name="logger">The logger to use for logging.</param>
     /// <param name="section">The configuration section to use.</param>
     /// <param name="id">The unique identifier for the client.</param>
     /// <param name="configure">An optional action to configure the client after creation.</param>
-    public ConfigurableChatClient(IConfiguration configuration, IClientFactory factory, ILogger logger, string section, string id, Action<string, IChatClient>? configure)
+    public ConfigurableChatClient(IConfiguration configuration, IClientFactoryResolver resolver, ILogger logger, string section, string id, Action<string, IChatClient>? configure)
     {
         if (section.Contains('.'))
             throw new ArgumentException("Section separator must be ':', not '.'");
 
         this.configuration = Throw.IfNull(configuration);
-        this.factory = Throw.IfNull(factory);
+        this.resolver = Throw.IfNull(resolver);
         this.logger = Throw.IfNull(logger);
         this.section = Throw.IfNullOrEmpty(section);
         this.id = Throw.IfNullOrEmpty(id);
@@ -41,14 +41,14 @@ public sealed partial class ConfigurableChatClient : IChatClient, IDisposable
         reloadToken = configuration.GetReloadToken().RegisterChangeCallback(OnReload, state: null);
     }
 
-    /// <summary>Initializes a new instance of the <see cref="ConfigurableChatClient"/> class using the default <see cref="ClientFactory"/>.</summary>
+    /// <summary>Initializes a new instance of the <see cref="ConfigurableChatClient"/> class using the default <see cref="ClientFactoryResolver"/>.</summary>
     /// <param name="configuration">The configuration to read settings from.</param>
     /// <param name="logger">The logger to use for logging.</param>
     /// <param name="section">The configuration section to use.</param>
     /// <param name="id">The unique identifier for the client.</param>
     /// <param name="configure">An optional action to configure the client after creation.</param>
     public ConfigurableChatClient(IConfiguration configuration, ILogger logger, string section, string id, Action<string, IChatClient>? configure)
-        : this(configuration, ClientFactory.CreateDefault(), logger, section, id, configure)
+        : this(configuration, ClientFactoryResolver.CreateDefault(), logger, section, id, configure)
     {
     }
 
@@ -97,7 +97,7 @@ public sealed partial class ConfigurableChatClient : IChatClient, IDisposable
         // Create a configuration section wrapper that includes the resolved apikey
         var effectiveSection = new ApiKeyResolvingConfigurationSection(configSection, apikey);
 
-        var client = factory.CreateChatClient(effectiveSection);
+        var client = resolver.Resolve(effectiveSection).CreateChatClient();
         configure?.Invoke(id, client);
         LogConfigured(id);
 
@@ -134,7 +134,54 @@ public sealed partial class ConfigurableChatClient : IChatClient, IDisposable
 
         public string Key => inner.Key;
         public string Path => inner.Path;
-        public string? Value { get => inner.Value; set => inner.Value = value; }
+        public string? Value
+        {
+            get => inner.Value;
+            set => inner.Value = value;
+        }
+        public IEnumerable<IConfigurationSection> GetChildren()
+        {
+            var hasApiKey = false;
+
+            foreach (var child in inner.GetChildren())
+            {
+                if (string.Equals(child.Key, "apikey", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasApiKey = true;
+                    yield return new ApiKeyValueConfigurationSection(child, resolvedApiKey);
+                }
+                else
+                {
+                    yield return child;
+                }
+            }
+
+            if (!hasApiKey && resolvedApiKey is not null)
+                yield return new ApiKeyValueConfigurationSection(inner.GetSection("apikey"), resolvedApiKey);
+        }
+        public IChangeToken GetReloadToken() => inner.GetReloadToken();
+        public IConfigurationSection GetSection(string key)
+            => string.Equals(key, "apikey", StringComparison.OrdinalIgnoreCase)
+                ? new ApiKeyValueConfigurationSection(inner.GetSection(key), resolvedApiKey)
+                : inner.GetSection(key);
+    }
+
+    sealed class ApiKeyValueConfigurationSection(IConfigurationSection inner, string? resolvedApiKey) : IConfigurationSection
+    {
+        public string? this[string key]
+        {
+            get => inner[key];
+            set => inner[key] = value;
+        }
+
+        public string Key => inner.Key;
+        public string Path => inner.Path;
+        public string? Value
+        {
+            get => resolvedApiKey ?? inner.Value;
+            set => inner.Value = value;
+        }
+
         public IEnumerable<IConfigurationSection> GetChildren() => inner.GetChildren();
         public IChangeToken GetReloadToken() => inner.GetReloadToken();
         public IConfigurationSection GetSection(string key) => inner.GetSection(key);

--- a/src/Extensions/ConfigurableChatClientExtensions.cs
+++ b/src/Extensions/ConfigurableChatClientExtensions.cs
@@ -62,7 +62,7 @@ public static class ConfigurableChatClientExtensions
                 factory: (sp, _) =>
                 {
                     var client = new ConfigurableChatClient(configuration,
-                        sp.GetRequiredService<IClientFactory>(),
+                        sp.GetRequiredService<ClientFactoryResolver>(),
                         sp.GetRequiredService<ILogger<ConfigurableChatClient>>(),
                         section, id, configureClient);
 
@@ -88,6 +88,14 @@ public static class ConfigurableChatClientExtensions
     /// <summary>Gets a chat client by id (case-insensitive) from the service provider.</summary>
     public static IChatClient? GetChatClient(this IServiceProvider services, string id)
         => services.GetKeyedService<IChatClient>(id) ?? services.GetKeyedService<IChatClient>(new ServiceKey(id));
+
+    /// <summary>Gets a text to speech client by id (case-insensitive) from the service provider.</summary>
+    public static ITextToSpeechClient? GetTextToSpeechClient(this IServiceProvider services, string id)
+        => services.GetKeyedService<ITextToSpeechClient>(id) ?? services.GetKeyedService<ITextToSpeechClient>(new ServiceKey(id));
+
+    /// <summary>Gets a speech to text client by id (case-insensitive) from the service provider.</summary>
+    public static ISpeechToTextClient? GetSpeechToTextClient(this IServiceProvider services, string id)
+        => services.GetKeyedService<ISpeechToTextClient>(id) ?? services.GetKeyedService<ISpeechToTextClient>(new ServiceKey(id));
 
     internal class ChatClientOptions : OpenAIClientOptions
     {

--- a/src/Extensions/ConfigurableClientExtensions.cs
+++ b/src/Extensions/ConfigurableClientExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using Devlooped.Extensions.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>Adds configuration-driven AI clients to an application host or service collection.</summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class ConfigurableClientExtensions
+{
+    /// <summary>
+    /// Adds configuration-driven chat clients to the host application builder.
+    /// </summary>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configurePipeline">Optional action to configure the pipeline for each client.</param>
+    /// <param name="configureClient">Optional action to configure each client.</param>
+    /// <param name="prefix">The configuration prefix for clients. Defaults to "ai:clients".</param>
+    /// <param name="useDefaultProviders">Whether to register the default built-in <see cref="IClientProvider"/> providers for mapping configuration sections to <see cref="IChatClient"/> instances.</param>
+    /// <returns>The host application builder.</returns>
+    public static TBuilder AddAIClients<TBuilder>(this TBuilder builder,
+        Action<string, ChatClientBuilder>? configureChat = default,
+        Action<string, TextToSpeechClientBuilder>? configureTTS = default,
+        Action<string, SpeechToTextClientBuilder>? configureSTT = default,
+        string prefix = "ai:clients", bool useDefaultProviders = true)
+        where TBuilder : IHostApplicationBuilder
+    {
+        return builder;
+    }
+}

--- a/src/Extensions/IClientFactory.cs
+++ b/src/Extensions/IClientFactory.cs
@@ -3,37 +3,24 @@ using Microsoft.Extensions.Configuration;
 
 namespace Devlooped.Extensions.AI;
 
-/// <summary>A factory for creating AI clients based on configuration.</summary>
+/// <summary>A factory for creating AI clients based on a bound configuration section.</summary>
 /// <remarks>
-/// The factory resolves the appropriate <see cref="IClientProvider"/> using the following logic:
-/// <list type="number">
-///   <item><description>If the configuration section contains a <c>provider</c> key, looks up a provider by name.</description></item>
-///   <item><description>Otherwise, matches the <c>endpoint</c> URI against registered providers' base URIs or host suffix, if any.</description></item>
-///   <item><description>If no match is found, throws an <see cref="InvalidOperationException"/>.</description></item>
-/// </list>
+/// Instances are created by an <see cref="IClientProvider"/> for a specific
+/// <see cref="IConfigurationSection"/>, then reused to create clients against that section.
 /// </remarks>
 public interface IClientFactory
 {
-    /// <summary>Creates an <see cref="IChatClient"/> using the specified configuration section.</summary>
-    /// <param name="section">The configuration section containing client settings including 
-    /// <c>endpoint</c>, <c>apikey</c>, <c>modelid</c>, and optionally <c>provider</c>.</param>
+    /// <summary>Creates an <see cref="IChatClient"/> using the bound configuration section.</summary>
     /// <returns>A configured <see cref="IChatClient"/> instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no matching provider is found for the given configuration.</exception>
-    IChatClient CreateChatClient(IConfigurationSection section);
+    IChatClient CreateChatClient();
 
-    /// <summary>Creates an <see cref="ISpeechToTextClient"/> using the specified configuration section.</summary>
-    /// <param name="section">The configuration section containing client settings including 
-    /// <c>endpoint</c>, <c>apikey</c>, <c>modelid</c>, and optionally <c>provider</c>.</param>
+    /// <summary>Creates an <see cref="ISpeechToTextClient"/> using the bound configuration section.</summary>
     /// <returns>A configured <see cref="ISpeechToTextClient"/> instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no matching provider is found for the given configuration.</exception>
     /// <exception cref="NotSupportedException">Thrown when the resolved provider does not support speech-to-text clients.</exception>
-    ISpeechToTextClient CreateSpeechToTextClient(IConfigurationSection section);
+    ISpeechToTextClient CreateSpeechToTextClient();
 
-    /// <summary>Creates an <see cref="ITextToSpeechClient"/> using the specified configuration section.</summary>
-    /// <param name="section">The configuration section containing client settings including 
-    /// <c>endpoint</c>, <c>apikey</c>, <c>modelid</c>, and optionally <c>provider</c>.</param>
+    /// <summary>Creates an <see cref="ITextToSpeechClient"/> using the bound configuration section.</summary>
     /// <returns>A configured <see cref="ITextToSpeechClient"/> instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no matching provider is found for the given configuration.</exception>
     /// <exception cref="NotSupportedException">Thrown when the resolved provider does not support text-to-speech clients.</exception>
-    ITextToSpeechClient CreateTextToSpeechClient(IConfigurationSection section);
+    ITextToSpeechClient CreateTextToSpeechClient();
 }

--- a/src/Extensions/IClientFactoryResolver.cs
+++ b/src/Extensions/IClientFactoryResolver.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Devlooped.Extensions.AI;
+
+/// <summary>Resolves providers by name or by matching endpoint URIs, then returns section-bound factories.</summary>
+public interface IClientFactoryResolver
+{
+    /// <summary>Resolves the appropriate provider for the given configuration section and returns its bound factory.</summary>
+    /// <param name="section">The configuration section containing client settings.</param>
+    /// <returns>A provider-specific <see cref="IClientFactory"/> bound to <paramref name="section"/>.</returns>
+    IClientFactory Resolve(IConfigurationSection section);
+}

--- a/src/Extensions/IClientProvider.cs
+++ b/src/Extensions/IClientProvider.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Configuration;
+
 namespace Devlooped.Extensions.AI;
 
 /// <summary>
@@ -35,6 +37,6 @@ public interface IClientProvider
     /// </remarks>
     string? HostSuffix { get; }
 
-    /// <summary>Gets the provider-specific factory that knows how to create individual clients.</summary>
-    IClientFactory GetFactory();
+    /// <summary>Gets the provider-specific factory bound to the specified configuration section.</summary>
+    IClientFactory GetFactory(IConfigurationSection section);
 }

--- a/src/Tests/ConfigurableClientTests.cs
+++ b/src/Tests/ConfigurableClientTests.cs
@@ -411,13 +411,12 @@ public class ConfigurableClientTests(ITestOutputHelper output)
 
         var services = new ServiceCollection()
             .AddSingleton<IConfiguration>(configuration)
-            .AddClientFactory()
+            .AddClients(configuration)
             .BuildServiceProvider();
 
-        var factory = services.GetRequiredService<IClientFactory>();
-        var section = configuration.GetRequiredSection("ai:clients:openai");
-        var speechToText = factory.CreateSpeechToTextClient(section);
-        var textToSpeech = factory.CreateTextToSpeechClient(section);
+        var factory = services.GetRequiredKeyedService<IClientFactory>("ai:clients:openai");
+        var speechToText = factory.CreateSpeechToTextClient();
+        var textToSpeech = factory.CreateTextToSpeechClient();
 
         var speechOptions = Assert.IsType<OpenAIClientProvider.OpenAIProviderOptions>(
             speechToText.GetService(typeof(object), "options"));
@@ -443,10 +442,10 @@ public class ConfigurableClientTests(ITestOutputHelper output)
             })
             .Build();
 
-        var factory = ClientFactory.CreateDefault();
         var section = configuration.GetRequiredSection("ai:clients:audio");
-        var speechToText = factory.CreateSpeechToTextClient(section);
-        var textToSpeech = factory.CreateTextToSpeechClient(section);
+        var factory = ClientFactoryResolver.CreateDefault().Resolve(section);
+        var speechToText = factory.CreateSpeechToTextClient();
+        var textToSpeech = factory.CreateTextToSpeechClient();
 
         var speechOptions = Assert.IsType<AzureOpenAIClientProvider.AzureOpenAIProviderOptions>(
             speechToText.GetService(typeof(object), "options"));
@@ -457,6 +456,34 @@ public class ConfigurableClientTests(ITestOutputHelper output)
         Assert.Same(textOptions, textToSpeech.GetService(typeof(AzureOpenAIClientProvider.AzureOpenAIProviderOptions), "options"));
         Assert.Equal(new Uri("https://chat.openai.azure.com/"), speechOptions.Endpoint);
         Assert.Equal("myapp/1.0", textOptions.UserAgentApplicationId);
+    }
+
+    [Fact]
+    public void CanInspectXAIProviderOptions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ai:clients:grok:modelid"] = "grok-4-fast",
+                ["ai:clients:grok:apikey"] = "xai-asdfasdf",
+                ["ai:clients:grok:endpoint"] = "https://api.x.ai",
+            })
+            .Build();
+
+        var section = configuration.GetRequiredSection("ai:clients:grok");
+        var factory = ClientFactoryResolver.CreateDefault().Resolve(section);
+
+        var chat = factory.CreateChatClient();
+        var speechToText = factory.CreateSpeechToTextClient();
+        var textToSpeech = factory.CreateTextToSpeechClient();
+
+        var speechOptions = speechToText.GetService<GrokClientOptions>();
+        var textOptions = textToSpeech.GetService<GrokClientOptions>();
+
+        Assert.Same(speechOptions, speechToText.GetService(typeof(object), "options"));
+        Assert.Same(textOptions, textToSpeech.GetService(typeof(object), "options"));
+
+        Assert.Equal("grok-4-fast", chat.GetRequiredService<GrokClientProvider.GrokProviderOptions>().ModelId);
     }
 
     [Fact]
@@ -471,13 +498,85 @@ public class ConfigurableClientTests(ITestOutputHelper output)
             })
             .Build();
 
-        var factory = ClientFactory.CreateDefault();
         var section = configuration.GetRequiredSection("ai:clients:azure");
+        var factory = ClientFactoryResolver.CreateDefault().Resolve(section);
 
-        var speechToText = Assert.Throws<NotSupportedException>(() => factory.CreateSpeechToTextClient(section));
-        var textToSpeech = Assert.Throws<NotSupportedException>(() => factory.CreateTextToSpeechClient(section));
+        var speechToText = Assert.Throws<NotSupportedException>(() => factory.CreateSpeechToTextClient());
+        var textToSpeech = Assert.Throws<NotSupportedException>(() => factory.CreateTextToSpeechClient());
 
         Assert.Contains(nameof(ISpeechToTextClient), speechToText.Message);
         Assert.Contains(nameof(ITextToSpeechClient), textToSpeech.Message);
+    }
+
+    [Fact]
+    public void CanResolveKeyedClientFactoryBySectionPath()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ai:clients:openai:modelid"] = "gpt-4.1.nano",
+                ["ai:clients:openai:apikey"] = "sk-asdfasdf",
+            })
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddClients(configuration)
+            .BuildServiceProvider();
+
+        var factory = services.GetRequiredKeyedService<IClientFactory>("ai:clients:openai");
+        var alternative = services.GetRequiredKeyedService<IClientFactory>(new ServiceKey("AI:CLIENTS:OPENAI"));
+        var client = factory.CreateChatClient();
+
+        Assert.Same(factory, alternative);
+        Assert.Equal("gpt-4.1.nano", client.GetRequiredService<ChatClientMetadata>().DefaultModelId);
+    }
+
+    [Fact]
+    public void AddClientsOnlyRegistersSectionsWithDirectApiKey()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ai:clients:grok:apikey"] = "xai-asdfasdf",
+                ["ai:clients:grok:router:modelid"] = "grok-4-fast",
+                ["ai:clients:grok:router:endpoint"] = "https://api.x.ai",
+            })
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddClients(configuration)
+            .BuildServiceProvider();
+
+        Assert.NotNull(services.GetKeyedService<IClientFactory>("ai:clients:grok"));
+        Assert.Null(services.GetKeyedService<IClientFactory>("ai:clients:grok:router"));
+    }
+
+    [Fact]
+    public void BoundFactoryReflectsConfigurationChanges()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ai:clients:openai:modelid"] = "gpt-4.1",
+                ["ai:clients:openai:apikey"] = "sk-asdfasdf",
+            })
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddClients(configuration)
+            .BuildServiceProvider();
+
+        var factory = services.GetRequiredKeyedService<IClientFactory>("ai:clients:openai");
+        var original = factory.CreateChatClient();
+
+        configuration["ai:clients:openai:modelid"] = "gpt-5";
+
+        var updated = factory.CreateChatClient();
+
+        Assert.Equal("gpt-4.1", original.GetRequiredService<ChatClientMetadata>().DefaultModelId);
+        Assert.Equal("gpt-5", updated.GetRequiredService<ChatClientMetadata>().DefaultModelId);
     }
 }

--- a/src/Tests/EndToEnd.cs
+++ b/src/Tests/EndToEnd.cs
@@ -1,0 +1,35 @@
+﻿using Json5;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Devlooped;
+
+public class EndToEnd
+{
+    static readonly IConfigurationRoot configuration = new ConfigurationBuilder()
+        .AddUserSecrets<EndToEnd>()
+        .AddJson5File("EndToEnd.json5")
+        .Build();
+
+    [SecretsFact("AI:Clients:XAI:ApiKey")]
+    public async Task GetText()
+    {
+        var services = new ServiceCollection()
+            .AddChatClients(configuration,
+                configurePipeline: (id, builder) => builder.UseLogging()
+                //configureClient: (id, client) => client.AsBuilder().UseLogging().build
+            )
+            .BuildServiceProvider();
+
+        var chat = services.GetChatClient("XAI");
+
+        Assert.NotNull(chat);
+
+        var hello = await chat.GetResponseAsync("Hi there!");
+
+        //var tts = services.GetChatClient.GetTextToSpeechClient("XAI");
+
+        //Assert.NotNull(tts);
+    }
+}

--- a/src/Tests/EndToEnd.json5
+++ b/src/Tests/EndToEnd.json5
@@ -1,0 +1,10 @@
+{
+    AI: {
+        Clients: {
+            XAI: {
+                Provider: "xai",
+                ModelId: "grok-latest"
+            }
+        }
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="Json5.Configuration" Version="1.0.4" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
@@ -43,6 +44,7 @@
 
   <ItemGroup>
     <None Update=".env" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="EndToEnd.json5" CopyToOutputDirectory="PreserveNewest" />
     <None Update="Content\**\*.*" CopyToOutputDirectory="PreserveNewest" />
     <Content Update="Content\**\*.*" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="*.json;*.ini;*.toml" Exclude="@(Content)" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Refactor configuration-driven client factory resolution

Bind client factories to configuration sections and resolve them through
IClientFactoryResolver and ClientFactoryResolver so configurable clients and
DI registrations are driven by section paths and service keys.

Validation:
- dotnet build Extensions.AI.slnx
- dotnet format whitespace -v:diag --exclude ~/.nuget
- dotnet format style -v:diag --exclude ~/.nuget
- dotnet test src\Tests\Tests.csproj --no-build --filter "FullyQualifiedName~ConfigurableClientTests"
- dotnet test src\Tests\Tests.csproj --no-build --filter "FullyQualifiedName!~Devlooped.EndToEnd"

Known issue:
- dnx --yes retest and the full test project currently fail because
  Devlooped.EndToEnd.GetText in src/Tests/EndToEnd.cs asserts
  GetChatClient("XAI") is not null for a config shape that does not register
  that chat client id.